### PR TITLE
Use `swiftlang/github-workflows` for Wasm in `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,8 @@ jobs:
       windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
       enable_macos_checks: true
       macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.0\"}, {\"xcode_version\": \"16.1\"}]"
+      enable_wasm_sdk_build: true
+      wasm_sdk_build_command: swift build --target ArgumentParser
 
   cmake-build:
     name: CMake Build
@@ -50,25 +52,6 @@ jobs:
         run: cmake -GNinja -S . -B .cmake-build -DBUILD_EXAMPLES=1 -DBUILD_TESTING=0
       - name: Build
         run: cmake --build .cmake-build
-
-  wasm-build:
-    name: Wasm Build
-    runs-on: ubuntu-latest
-    container:
-      image: swift:6.1-noble
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-      - name: Install Swift SDKs for WebAssembly
-        run: |
-          # TODO: We can replace these Swift SDKs with the swift.org one once it supports Foundation.
-          swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasi.artifactbundle.zip --checksum 7550b4c77a55f4b637c376f5d192f297fe185607003a6212ad608276928db992
-          swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasip1-threads.artifactbundle.zip --checksum 0dd273be28741f8e1eb00682c39bdc956361ed24b5572e183dd8a4e9d1c5f6ec
-          swift sdk list
-      - name: Build
-        run: |
-          swift build --swift-sdk wasm32-unknown-wasi --target ArgumentParser
-          swift build --swift-sdk wasm32-unknown-wasip1-threads --target ArgumentParser
 
   soundness:
     name: Soundness


### PR DESCRIPTION
As `swiftlang/github-workflows` supports Swift SDK for Wasm, we should rely on that instead of downloading Swift SDKs manually.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-argument-parser/blob/main/CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary
